### PR TITLE
Adding VL Supression Report

### DIFF
--- a/app/services/art_service/report_engine.rb
+++ b/app/services/art_service/report_engine.rb
@@ -12,6 +12,7 @@ module ArtService
       'ARCHIVING_CANDIDATES' => ArtService::Reports::ArchivingCandidates,
       'APPOINTMENTS' => ArtService::Reports::AppointmentsReport,
       'ARV_REFILL_PERIODS' => ArtService::Reports::ArvRefillPeriods,
+      'VL_SUPRESSION' => ArtService::Reports::Clinic::VlSupressionReport,
       'COHORT' => ArtService::Reports::ArtCohort,
       'COHORT_DISAGGREGATED' => ArtService::Reports::Cohort::Disaggregated,
       'COHORT_DISAGGREGATED_ADDITIONS' => ArtService::Reports::CohortDisaggregatedAdditions,

--- a/app/services/art_service/reports/clinic/vl_supression_report.rb
+++ b/app/services/art_service/reports/clinic/vl_supression_report.rb
@@ -13,7 +13,7 @@ module ArtService
           @start_date = start_date
           @end_date = end_date
           @occupation = kwargs[:occupation]
-          @type = kwargs[:type] || 'poc'
+          @type = kwargs[:system_type] || 'poc'
         end
 
         def find_report
@@ -69,7 +69,6 @@ module ArtService
                                                          end).each do |patient|
             # find the regimen for the patient using the clients array
             regimen = clients.find { |client| client['patient_id'] == patient['patient_id'] }['current_regimen']
-            puts "Patient: #{patient['patient_id']} is due for VL. Regimen: #{regimen}"
             report[regimen][:drawn] << patient['patient_id']
             next unless patient['result_value']
 

--- a/app/services/art_service/reports/clinic/vl_supression_report.rb
+++ b/app/services/art_service/reports/clinic/vl_supression_report.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+module ArtService
+  module Reports
+    module Clinic
+      # This class is responsible for generating the VL Suppression report
+      class VlSupressionReport
+        attr_accessor :start_date, :end_date, :occupation, :type, :report
+
+        include ArtService::Reports::Pepfar::Utils
+
+        def initialize(start_date:, end_date:, **kwargs)
+          @start_date = start_date
+          @end_date = end_date
+          @occupation = kwargs[:occupation]
+          @type = kwargs[:type] || 'poc'
+        end
+
+        def find_report
+          init_report
+          fetch_due_clients
+          flatten_data
+        end
+
+        private
+
+        def init_report
+          @report = COHORT_REGIMENS.each_with_object({}) do |regimen, report|
+            report[regimen] = {
+              due_for_vl: [],
+              drawn: [],
+              high_vl: [],
+              low_vl: []
+            }
+          end
+          @report['N/A'] = { due_for_vl: [], drawn: [], high_vl: [], low_vl: [] }
+        end
+
+        def fetch_due_clients
+          clients = coverage_service.process_due_people
+          clients.each do |patient|
+            regimen = patient['current_regimen']
+            regimen = regimen.gsub(/(\d+[A-Za-z]*P)\z/, '\1P') if regimen.match?(/\A\d+[A-Za-z]*[^P]P\z/)
+            patient['current_regimen'] = regimen
+            report[regimen][:due_for_vl] << patient['patient_id']
+          end
+          load_patient_tests_into_report(clients)
+        end
+
+        # rubocop:disable Metrics/MethodLength
+        def flatten_data
+          flat_data = []
+          report.each do |regimen, data|
+            flat_data << {
+              regimen:,
+              due_for_vl: data[:due_for_vl],
+              drawn: data[:drawn],
+              high_vl: data[:high_vl],
+              low_vl: data[:low_vl]
+            }
+          end
+          flat_data
+        end
+
+        # rubocop:disable Metrics/AbcSize
+        def load_patient_tests_into_report(clients)
+          coverage_service.find_patients_with_viral_load(clients.map do |patient|
+                                                           patient['patient_id']
+                                                         end).each do |patient|
+            # find the regimen for the patient using the clients array
+            regimen = clients.find { |client| client['patient_id'] == patient['patient_id'] }['current_regimen']
+            puts "Patient: #{patient['patient_id']} is due for VL. Regimen: #{regimen}"
+            report[regimen][:drawn] << patient['patient_id']
+            next unless patient['result_value']
+
+            if patient['result_value'].casecmp?('LDL')
+              report[regimen][:low_vl] << patient['patient_id']
+            elsif patient['result_value'].to_i < 1000
+              report[regimen][:low_vl] << patient['patient_id']
+            else
+              report[regimen][:high_vl] << patient['patient_id']
+            end
+          end
+        end
+        # rubocop:enable Metrics/AbcSize
+        # rubocop:enable Metrics/MethodLength
+
+        def coverage_service
+          @coverage_service ||= ArtService::Reports::Pepfar::ViralLoadCoverage2.new(
+            start_date:,
+            end_date:,
+            occupation:,
+            type:
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/services/art_service/reports/pepfar/viral_load_coverage2.rb
+++ b/app/services/art_service/reports/pepfar/viral_load_coverage2.rb
@@ -74,6 +74,78 @@ module ArtService
         # rubocop:enable Metrics/CyclomaticComplexity
         # rubocop:enable Metrics/MethodLength
 
+        ##
+        # Find all patients that are on treatment with at least one VL before end of reporting period.
+        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable Metrics/MethodLength
+        def find_patients_with_viral_load(clients)
+          ActiveRecord::Base.connection.select_all <<~SQL
+            SELECT orders.patient_id,
+                   disaggregated_age_group(patient.birthdate,
+                                                  DATE(#{ActiveRecord::Base.connection.quote(end_date)})) AS age_group,
+                   patient.birthdate,
+                   LEFT(patient.gender, 1) gender,
+                   patient_identifier.identifier AS arv_number,
+                   orders.start_date AS order_date,
+                   COALESCE(orders.discontinued_date, orders.start_date) AS sample_draw_date,
+                   COALESCE(reason_for_test_value.name, reason_for_test.value_text) AS reason_for_test,
+                   result.value_modifier AS result_modifier,
+                   COALESCE(result.value_numeric, result.value_text) AS result_value
+            FROM orders
+            INNER JOIN person patient ON patient.person_id = orders.patient_id AND patient.voided = 0
+            INNER JOIN order_type
+              ON order_type.order_type_id = orders.order_type_id
+              AND order_type.name = 'Lab'
+              AND order_type.retired = 0
+            INNER JOIN concept_name
+              ON concept_name.concept_id = orders.concept_id
+              AND concept_name.name IN ('Blood', 'DBS (Free drop to DBS card)', 'DBS (Using capillary tube)', 'Plasma')
+              AND concept_name.voided = 0
+            LEFT JOIN obs AS reason_for_test
+              ON reason_for_test.order_id = orders.order_id
+              AND reason_for_test.concept_id IN (SELECT concept_id FROM concept_name WHERE name LIKE 'Reason for test' AND voided = 0)
+              AND reason_for_test.voided = 0
+            LEFT JOIN concept_name AS reason_for_test_value
+              ON reason_for_test_value.concept_id = reason_for_test.value_coded
+              AND reason_for_test_value.voided = 0
+            LEFT JOIN obs AS result
+              ON result.order_id = orders.order_id
+              AND result.concept_id IN (SELECT concept_id FROM concept_name WHERE name LIKE 'HIV Viral load' AND voided = 0)
+              AND result.voided = 0
+              AND (result.value_text IS NOT NULL OR result.value_numeric IS NOT NULL)
+            INNER JOIN (
+              /* Get the latest order dates for each patient */
+              SELECT orders.patient_id, MAX(orders.start_date) AS start_date
+              FROM orders
+              INNER JOIN order_type
+                ON order_type.order_type_id = orders.order_type_id
+                AND order_type.name = 'Lab'
+                AND order_type.retired = 0
+              INNER JOIN concept_name
+                ON concept_name.concept_id = orders.concept_id
+                AND concept_name.name IN ('Blood', 'DBS (Free drop to DBS card)', 'DBS (Using capillary tube)', 'Plasma')
+                AND concept_name.voided = 0
+              WHERE orders.start_date < DATE(#{ActiveRecord::Base.connection.quote(end_date)}) + INTERVAL 1 DAY
+                AND orders.start_date >= DATE(#{ActiveRecord::Base.connection.quote(start_date)}) - INTERVAL 12 MONTH
+                AND orders.voided = 0
+              GROUP BY orders.patient_id
+            ) AS latest_patient_order_date
+              ON latest_patient_order_date.patient_id = orders.patient_id
+              AND latest_patient_order_date.start_date = orders.start_date
+            LEFT JOIN patient_identifier
+              ON patient_identifier.patient_id = orders.patient_id
+              AND patient_identifier.identifier_type IN (#{pepfar_patient_identifier_type.to_sql})
+              AND patient_identifier.voided = 0
+            WHERE orders.start_date < DATE(#{ActiveRecord::Base.connection.quote(end_date)}) + INTERVAL 1 DAY
+              AND orders.start_date >= DATE(#{ActiveRecord::Base.connection.quote(start_date)}) - INTERVAL 12 MONTH
+              AND orders.voided = 0
+              AND orders.patient_id IN (#{clients.push(0).join(',')})
+            GROUP BY orders.patient_id
+          SQL
+        end
+        # rubocop:enable Metrics/AbcSize
+        # rubocop:enable Metrics/MethodLength
+
         private
 
         # rubocop:disable Metrics/AbcSize
@@ -338,79 +410,6 @@ module ArtService
             current_pepfar_defaulter_date(#{patient_id}, DATE(#{ActiveRecord::Base.connection.quote(end_date)})) AS defaulter_date
           SQL
         end
-
-        ##
-        # Find all patients that are on treatment with at least one VL before end of reporting period.
-        # rubocop:disable Metrics/AbcSize
-        # rubocop:disable Metrics/MethodLength
-
-        def find_patients_with_viral_load(clients)
-          ActiveRecord::Base.connection.select_all <<~SQL
-            SELECT orders.patient_id,
-                   disaggregated_age_group(patient.birthdate,
-                                                  DATE(#{ActiveRecord::Base.connection.quote(end_date)})) AS age_group,
-                   patient.birthdate,
-                   LEFT(patient.gender, 1) gender,
-                   patient_identifier.identifier AS arv_number,
-                   orders.start_date AS order_date,
-                   COALESCE(orders.discontinued_date, orders.start_date) AS sample_draw_date,
-                   COALESCE(reason_for_test_value.name, reason_for_test.value_text) AS reason_for_test,
-                   result.value_modifier AS result_modifier,
-                   COALESCE(result.value_numeric, result.value_text) AS result_value
-            FROM orders
-            INNER JOIN person patient ON patient.person_id = orders.patient_id AND patient.voided = 0
-            INNER JOIN order_type
-              ON order_type.order_type_id = orders.order_type_id
-              AND order_type.name = 'Lab'
-              AND order_type.retired = 0
-            INNER JOIN concept_name
-              ON concept_name.concept_id = orders.concept_id
-              AND concept_name.name IN ('Blood', 'DBS (Free drop to DBS card)', 'DBS (Using capillary tube)', 'Plasma')
-              AND concept_name.voided = 0
-            LEFT JOIN obs AS reason_for_test
-              ON reason_for_test.order_id = orders.order_id
-              AND reason_for_test.concept_id IN (SELECT concept_id FROM concept_name WHERE name LIKE 'Reason for test' AND voided = 0)
-              AND reason_for_test.voided = 0
-            LEFT JOIN concept_name AS reason_for_test_value
-              ON reason_for_test_value.concept_id = reason_for_test.value_coded
-              AND reason_for_test_value.voided = 0
-            LEFT JOIN obs AS result
-              ON result.order_id = orders.order_id
-              AND result.concept_id IN (SELECT concept_id FROM concept_name WHERE name LIKE 'HIV Viral load' AND voided = 0)
-              AND result.voided = 0
-              AND (result.value_text IS NOT NULL OR result.value_numeric IS NOT NULL)
-            INNER JOIN (
-              /* Get the latest order dates for each patient */
-              SELECT orders.patient_id, MAX(orders.start_date) AS start_date
-              FROM orders
-              INNER JOIN order_type
-                ON order_type.order_type_id = orders.order_type_id
-                AND order_type.name = 'Lab'
-                AND order_type.retired = 0
-              INNER JOIN concept_name
-                ON concept_name.concept_id = orders.concept_id
-                AND concept_name.name IN ('Blood', 'DBS (Free drop to DBS card)', 'DBS (Using capillary tube)', 'Plasma')
-                AND concept_name.voided = 0
-              WHERE orders.start_date < DATE(#{ActiveRecord::Base.connection.quote(end_date)}) + INTERVAL 1 DAY
-                AND orders.start_date >= DATE(#{ActiveRecord::Base.connection.quote(start_date)}) - INTERVAL 12 MONTH
-                AND orders.voided = 0
-              GROUP BY orders.patient_id
-            ) AS latest_patient_order_date
-              ON latest_patient_order_date.patient_id = orders.patient_id
-              AND latest_patient_order_date.start_date = orders.start_date
-            LEFT JOIN patient_identifier
-              ON patient_identifier.patient_id = orders.patient_id
-              AND patient_identifier.identifier_type IN (#{pepfar_patient_identifier_type.to_sql})
-              AND patient_identifier.voided = 0
-            WHERE orders.start_date < DATE(#{ActiveRecord::Base.connection.quote(end_date)}) + INTERVAL 1 DAY
-              AND orders.start_date >= DATE(#{ActiveRecord::Base.connection.quote(start_date)}) - INTERVAL 12 MONTH
-              AND orders.voided = 0
-              AND orders.patient_id IN (#{clients.push(0).join(',')})
-            GROUP BY orders.patient_id
-          SQL
-        end
-        # rubocop:enable Metrics/AbcSize
-        # rubocop:enable Metrics/MethodLength
 
         def yes_concepts
           @yes_concepts ||= ConceptName.where(name: 'Yes').select(:concept_id).map do |record|


### PR DESCRIPTION
## Context
* Adding a VL Suppression which depends on VL Coverage logic. Instead of gender and age group this report is focusing on the regimens.

## Endpoint
```rest
localhost:3000/api/v1/programs/1/reports/vl_supression?start_date=2023-01-01&end_date=2024-03-31&system_type=poc
```
system_type: can be poc and emastercard. Essentially POC uses multithreading to boost the performance of the reports

## Result
This is the output from this report. An array of these below objects

```json
{
    "regimen": "13A",
    "due_for_vl": [
      10139,
      27684,
      139934,
      239891,
      248481,
      249451
    ],
    "drawn": [
      10139,
      27684,
      139934,
      239891,
      248481
    ],
    "high_vl": [],
    "low_vl": [
      10139,
      27684,
      239891
    ]
  }
```

## Tickets
[ShortCut](https://app.shortcut.com/egpaf-2/story/2435/clinic-suppression-by-regimen-report)
[POC Implementatation](https://github.com/EGPAFMalawiHIS/HIS-Core/pull/990)