### PR TITLE
Removing Discontinued Drugs

### DIFF
--- a/app/models/drug.rb
+++ b/app/models/drug.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# This does not inherit from RetirableRecord because of historical data. Inheriting from RetirableRecord will cause
+# retired drugs to not be displayed in the drug list.
 class Drug < ActiveRecord::Base
   self.table_name = :drug
   self.primary_key = :drug_id

--- a/app/services/art_service/regimen_engine.rb
+++ b/app/services/art_service/regimen_engine.rb
@@ -3,10 +3,32 @@
 module ArtService
   # TODO: This module reads like noise, it needs a re-write or even better,
   #       a complete rewrite.
+
+  # rubocop:disable Metrics/ClassLength
   class RegimenEngine
     include ModelUtils
 
     LOGGER = Rails.logger
+    DISCONTINUED_DRUGS = ['d4T (Stavudine 30mg tablet)',
+                          'd4T (Stavudine 40mg tablet)',
+                          'd4T (Stavudine 20mg tablet)',
+                          'd4T (Stavudine 15mg tablet)',
+                          'd4T (Stavudine syrup)',
+                          'Triomune-40',
+                          'Triomune baby (d4T/3TC/NVP 6/30/50mg tablet)',
+                          'd4T/3TC/NVP (30/150/200mg tablet)',
+                          'Triomune junior (d4T/3TC/NVP 12/60/100mg tablet)',
+                          'DDI (Didanosine 125mg tablet)',
+                          'DDI (Didanosine 200mg tablet)',
+                          'd4T/3TC/EFV (Stavudine Lamvudine Efavirenz)',
+                          'Coviro30 (Lamivudine + Stavudine 150/30 mg tablet)',
+                          'Coviro40 (Lamivudine + Stavudine 150/40mg tablet)',
+                          'd4T/3TC (Stavudine Lamivudine 6/30mg tablet)',
+                          'd4T/3TC (Stavudine Lamivudine 30/150 tablet)',
+                          'DDI/ABC/LPV/r',
+                          'TDF/d4T (Tenofavir and Stavudine 300/300mg tablet',
+                          'LPV/r pellets',
+                          'LPV/r Granules'].freeze
 
     def initialize(program:)
       @program = program
@@ -22,7 +44,7 @@ module ArtService
       arv_extras_concepts = Concept.joins(:concept_names).where(
         concept_name: { name: ['INH', 'CPT', 'Pyridoxine', 'Rifapentine', 'INH / RFP'] }
       )
-      Drug.where(concept: arv_extras_concepts) + Drug.arv_drugs.order(name: :desc)
+      Drug.where(concept: arv_extras_concepts) + Drug.arv_drugs.order(name: :desc).where.not(name: DISCONTINUED_DRUGS)
     end
 
     def regimen_extras(patient_weight:, name: nil)
@@ -517,4 +539,5 @@ module ArtService
       '17' => [Set.new([30, 1044]), Set.new([11, 969])]
     }.freeze
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/app/services/art_service/regimen_engine.rb
+++ b/app/services/art_service/regimen_engine.rb
@@ -28,7 +28,13 @@ module ArtService
                           'DDI/ABC/LPV/r',
                           'TDF/d4T (Tenofavir and Stavudine 300/300mg tablet',
                           'LPV/r pellets',
-                          'LPV/r Granules'].freeze
+                          'LPV/r Granules',
+                          'Triomune-30',
+                          'LS30 (Stavudine and Lamivudine 30mg tablet)',
+                          'Lamivir baby (Stavudine and Lamivudine 6/30mg tablet',
+                          'D4T+3TC/D4T+3TC+NVP',
+                          'TDF/3TC + ALT/r',
+                          'AZT/3TC + ALT/r'].freeze
 
     def initialize(program:)
       @program = program

--- a/app/services/art_service/regimen_engine.rb
+++ b/app/services/art_service/regimen_engine.rb
@@ -31,7 +31,7 @@ module ArtService
                           'LPV/r Granules',
                           'Triomune-30',
                           'LS30 (Stavudine and Lamivudine 30mg tablet)',
-                          'Lamivir baby (Stavudine and Lamivudine 6/30mg tablet',
+                          'Lamivir baby (Stavudine and Lamivudine 6/30mg tabl',
                           'D4T+3TC/D4T+3TC+NVP',
                           'TDF/3TC + ALT/r',
                           'AZT/3TC + ALT/r'].freeze


### PR DESCRIPTION
## Context
* We have a list of drugs that should not appear in treatment section

Below is the list of the drugs
```sh
* d4T (Stavudine 30mg tablet)
* d4T (Stavudine 40mg tablet)
* d4T (Stavudine 20mg tablet)
* d4T (Stavudine 15mg tablet)
* d4T (Stavudine syrup)
* Triomune-40
* Triomune baby (d4T/3TC/NVP 6/30/50mg tablet)
* d4T/3TC/NVP (30/150/200mg tablet)
* Triomune junior (d4T/3TC/NVP 12/60/100mg tablet)
* DDI (Didanosine 125mg tablet)
* DDI (Didanosine 200mg tablet)
* d4T/3TC/EFV (Stavudine Lamvudine Efavirenz)
* Coviro30 (Lamivudine + Stavudine 150/30 mg tablet)
* Coviro40 (Lamivudine + Stavudine 150/40mg tablet)
* d4T/3TC (Stavudine Lamivudine 6/30mg tablet)
* d4T/3TC (Stavudine Lamivudine 30/150 tablet)
* DDI/ABC/LPV/r
* TDF/d4T (Tenofavir and Stavudine 300/300mg tablet
* LPV/r pellets
* LPV/r Granules
```

## Tickets
[Shorcut](https://app.shortcut.com/egpaf-2/story/3340/system-maintaining-retired-phased-out-drugs)