### PR TITLE
VL Register Fix

### DIFF
--- a/app/services/art_service/reports/lims_results.rb
+++ b/app/services/art_service/reports/lims_results.rb
@@ -25,7 +25,6 @@ module ArtService
           las.date_received, o.accession_number, CONCAT(COALESCE(res.value_modifier, '='), COALESCE(res.value_text, res.value_numeric)) AS result,
           cn.name AS test_name, las.acknowledgement_type AS result_delivery_mode, statuses.value_text AS order_status, reason_test.name AS test_reason
           FROM orders o
-          INNER JOIN lab_lims_order_mappings llom ON llom.order_id = o.order_id
           LEFT JOIN lims_acknowledgement_statuses las ON las.order_id = o.order_id
           INNER JOIN encounter e ON e.encounter_id = o.encounter_id AND e.voided = 0 AND (e.program_id = 1 OR e.program_id = 23) -- HIV PROGRAM AND Laboratory program
           INNER JOIN users u ON u.user_id = o.orderer


### PR DESCRIPTION
## Context
* It was reported that the report is not showing results that were entered manually.
* The main issue was on the lab_mapping join that was causing orders that had received results before being mapped not to show. 

## Ticket
[Short Cut Issue](https://app.shortcut.com/egpaf-2/story/3299/vl-report-to-include-results-entered-manually)