### PR TITLE
fix(LOS): return value coded

### DIFF
--- a/app/services/laboratory_service/reports/clinic/samples_drawn.rb
+++ b/app/services/laboratory_service/reports/clinic/samples_drawn.rb
@@ -46,7 +46,7 @@ module LaboratoryService
                    person.birthdate,
                    patient_identifier.identifier AS arv_number,
                    disaggregated_age_group(person.birthdate, #{end_date}) AS age_group,
-                   reason_for_test.name AS reason_for_test,
+                   reason_for_test_obs.value_coded AS reason_for_test,
                    GROUP_CONCAT(DISTINCT test_concepts.name SEPARATOR ',') AS tests
             FROM orders
             INNER JOIN order_type


### PR DESCRIPTION
## Context
*Concept ID having different names, therefore in EMR its showing a different name and in LOS also a different name*

## Changes in the codebase

Return a value coded as the reason for test so that its translated in the frontend using the concept name dictionary

## Changes outside the codebase

[See Link for Frontend PR](https://github.com/EGPAFMalawiHIS/HIS-Core/pull/1018)

## Ticket

[Shortcut Link](https://app.shortcut.com/egpaf-2/story/3855/lab-ordering-reason-for-test-is-targeted?team_id=1861)
[Another One](https://app.shortcut.com/egpaf-2/story/3856/lab-ordering-reason-for-test-is-routine?team_id=1861)