### PR TITLE
Fix: Revised drill response to include person ID

### DIFF
--- a/app/services/art_service/reports/art_cohort.rb
+++ b/app/services/art_service/reports/art_cohort.rb
@@ -85,7 +85,7 @@ module ArtService
 
         ActiveRecord::Base.connection.select_all <<~SQL
           SELECT i.identifier arv_number, p.birthdate,
-                 p.gender, n.given_name, n.family_name, p.person_id patient_id,
+                 p.gender, n.given_name, n.family_name, p.person_id person_id,
                  outcomes.cum_outcome AS outcome, tesd.earliest_start_date art_start_date
           FROM person p
           INNER JOIN cohort_drill_down c ON c.patient_id = p.person_id


### PR DESCRIPTION
### About
- This PR resolves shortcut issue number [4330](https://app.shortcut.com/egpaf-2/story/4330/emc-cohort-report-drildown-not-brining-the-client-mastercard-when-a-client-is-clicked)