### PR TITLE
Bug Fix: Custom Periods in PEPFAR Reports

### DIFF
--- a/app/services/art_service/reports/cohort_builder.rb
+++ b/app/services/art_service/reports/cohort_builder.rb
@@ -19,14 +19,14 @@ module ArtService
         @outcomes_definition = outcomes_definition
       end
 
-      def init_temporary_tables(_start_date, end_date, occupation)
+      def init_temporary_tables(start_date, end_date, occupation)
         prepare_tables
         load_temp_other_patient_types(end_date)
         load_temp_register_start_date_table(end_date)
         load_temp_order_details(end_date)
         load_art_start_date(end_date)
         load_data_into_temp_earliest_start_date(end_date.to_date, occupation)
-        update_cum_outcome(end_date)
+        update_cum_outcome(start_date:, end_date:)
       end
 
       def build(cohort_struct, start_date, end_date, occupation)
@@ -292,7 +292,7 @@ module ArtService
         cohort_struct.quarterly_kaposis_sarcoma = kaposis_sarcoma(quarter_start_date, end_date)
 
         # From this point going down: we update temp_earliest_start_date cum_outcome field to have the latest Cumulative outcome
-        update_cum_outcome(end_date)
+        update_cum_outcome(start_date: quarter_start_date, end_date:)
         update_tb_status(end_date)
         update_patient_side_effects(end_date)
 
@@ -811,8 +811,8 @@ module ArtService
       # rubocop:enable Metrics/MethodLength
       # rubocop:enable Metrics/AbcSize
 
-      def update_cum_outcome(end_date)
-        ArtService::Reports::Cohort::Outcomes.new(end_date:,
+      def update_cum_outcome(start_date:, end_date:)
+        ArtService::Reports::Cohort::Outcomes.new(end_date:, start_date:,
                                                   definition: @outcomes_definition,
                                                   rebuild: 'true').update_cummulative_outcomes
       end


### PR DESCRIPTION
## Context
* This fixes the issue that no matter the custom period specified by the user the reports where defaulting to the quarterly periods.
* This has been noted in Mangochi and Phalombe (Baylor sites)
* This is affecting tracking of clients who have returned to care.
* Affected reports TX_RTT and TX_ML

@KytonThaundi  to add the TICKET in both helpdesk and Shortcut.
