### PR TITLE
Fix issue loading Art regimens after TB update

### DIFF
--- a/app/controllers/api/v1/program_regimens_controller.rb
+++ b/app/controllers/api/v1/program_regimens_controller.rb
@@ -58,7 +58,7 @@ module Api
 
       def service
         program_id = params.require(:program_id)
-        TbService::RegimenEngine.new(program: Program.find(program_id))
+        RegimenService.new(program_id:)
       end
     end
   end


### PR DESCRIPTION
## Context
TB service was hardcoded for retrieving regimens instead of using the RegimenService engine

## Ticket
https://app.shortcut.com/egpaf-2/story/4570/issue-loading-art-regimens-after-tb-update