### PR TITLE
[Fix: Cxca] Workflow unable to proceed

### DIFF
--- a/app/services/cxca_service/workflow_engine.rb
+++ b/app/services/cxca_service/workflow_engine.rb
@@ -220,6 +220,7 @@ module CxcaService
         @patient.patient_id, encounter_type.encounter_type_id, @date
       ).order(encounter_datetime: :desc).first
 
+      return false if encounter.blank?
       result = encounter.observations.where(concept_id: concept("Treatment").concept_id,
                                             value_coded: [
                                               concept("Palliative Care").concept_id,


### PR DESCRIPTION
## Context
Workflow was crashing for Cxca patients

## Description
Caused by unhandled null encounter on patient_outcome function
