### PR TITLE
[TB Workflow] Dont capture Tb Number for transferrin out clients

### DIFF
--- a/app/services/tb_service/workflow_engine.rb
+++ b/app/services/tb_service/workflow_engine.rb
@@ -99,6 +99,7 @@ module TbService
       TB_RECEPTION => %i[no_tb_reception? patient_should_proceed_for_treatment?],
 
       TB_REGISTRATION => %i[patient_needs_registration_number?
+                            not_transferring_to_another_facility?
                             patient_should_proceed_for_treatment?
                             patient_is_no_a_referral?],
 
@@ -298,6 +299,13 @@ module TbService
 
     def patient_should_go_for_appointment?
       (patient_has_dispensation? && patient_is_not_a_transfer_out? && patient_has_no_appointment? && patient_should_proceed_for_treatment?)
+    end
+
+    def not_transferring_to_another_facility?
+      tb_reception_ref('Patient transferred(external facility)')\
+              .where(value_coded: concept('YES').concept_id)\
+              .order(obs_datetime: :desc).first
+              .blank?
     end
 
     def patient_is_not_a_transfer_out?


### PR DESCRIPTION
## Context
For new registering clients who don't live close to the current TB facility and want to transferout, dont invoke Tb registration encounter

## Shortcut
https://app.shortcut.com/egpaf-2/story/4677/allow-user-to-complete-the-first-visit-up-to-dispensation-when-a-client-is-not-going-to-take-treatment-at-the-tb-diagnosing