### PR TITLE
move back 1 year for quarterly reports

### DIFF
--- a/app/services/tb_service/report_engine.rb
+++ b/app/services/tb_service/report_engine.rb
@@ -27,6 +27,12 @@ module TbService
       report = REPORTS[type.upcase]
       raise InvalidParameterError, "Report type (#{type}) not known" unless report
 
+      #  for TB quarterly reports, the report is calculated for the previous year
+      if type.upcase == 'QUARTERLY'
+        start_date = start_date.to_date - 1.year
+        end_date = end_date.to_date - 1.year
+      end
+
       indicator = report.method(name.strip.to_sym)
       raise InvalidParameterError, "Report indicator (#{name}) not known" unless indicator
 


### PR DESCRIPTION
## Context

For All TB quarterly outcome reports, search for 1 year back

Source: @KytonThaundi


[Shortcut](https://app.shortcut.com/egpaf-2/story/4685/align-tb-quarterly-outcomes-report-to-ntp-definition)