### PR TITLE
feat: Implemented APK updates end-points

### DIFF
--- a/app/controllers/apk_controller.rb
+++ b/app/controllers/apk_controller.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class ApkController < ApplicationController
+  skip_before_action :authenticate
+
+  def download
+    # get the version from the request
+    version = params[:version]
+    # check if the version is provided
+    if version.nil?
+      render json: { status: 'Error', error: 'Version not provided' }
+      return
+    end
+    send_file "/var/www/EMR-APK/EMR-#{version}.apk", type: 'application/vnd.android.package-archive', filename: "EMR-#{version}.apk"
+  rescue StandardError => e
+    logger.error "APK not found: #{e}"
+    render json: {
+      status: 'APK not found',
+      error: 'APK not found. Please check the path /var/www/EMR-APK/'
+    }
+  end
+
+
+  
+  # Read the available apk version
+  # 
+  # latest apk version is stored as /var/www/EMR-APK/EMR-[version].apk
+  # e.g. /var/www/EMR-APK/EMR-v2024.Q3.R3.apk where v2024.Q3.R3 is the version
+  #
+  # @return [JSON] The version of the system 
+  def version
+    # read the version of the apk file
+    tag = `ls /var/www/EMR-APK/EMR-*.apk | awk -F'/' '{print $NF}' | awk -F'-' '{print $2}' | sed 's/.apk$//'`.chomp
+    render json: { 'version': tag }
+
+  rescue StandardError => e
+    logger.error "APK not found: #{e}"
+    render json: { 
+      status: 'APK not found', 
+      error: 'APK not found. Please check the path /var/www/EMR-APK/' 
+    }
+  end
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -317,6 +317,8 @@ Rails.application.routes.draw do
   end
 
   root to: 'static#index'
+  get '/api/v1/apk_download', to: 'apk#download'
+  get '/api/v1/apk_version', to: 'apk#version'
   post '/api/v1/concept/find_by_ids', to: 'api/v1/concepts#find_names_by_ids'
   get '/api/v1/archiving_candidates' => 'api/v1/patients#find_archiving_candidates'
   get '/api/v1/_health' => 'healthcheck#index'


### PR DESCRIPTION
### Context
- Previously, users were distributing APKs manually using flash disks to install them on POS machines. This process was cumbersome and prone to errors. This PR introduces a new method for distributing APKs via an HTTP endpoint, streamlining the process and ensuring users always have access to the latest version.

Description
- This PR has introduced two end-points for retrieving latest version and and downloading apk file :
  - **The version endpoint** - retrieves latest version from the APK filename stored in `/var/www/EMR-APK/` directory
  - **The download endport** - Allows users to download a specific version of the APK file by providing the version as a parameter

### Additional information
- Ensure the directory /var/www/EMR-APK/ exists and contains the APK files in the expected format.
- These actions do not require authentication, making them publicly accessible.