### PR TITLE
feat(TB): add npt regimens in metadata migration script

### DIFF
--- a/bin/update_art_metadata.sh
+++ b/bin/update_art_metadata.sh
@@ -31,5 +31,6 @@ rails db:migrate && {
   mysql --host=$HOST --port=$PORT --user=$USERNAME --password=$PASSWORD $DATABASE < db/initial_setup/anc2_schema_additions.sql
   mysql --host=$HOST --port=$PORT --user=$USERNAME --password=$PASSWORD $DATABASE < db/sql/moh_regimens_v2021.sql
   mysql --host=$HOST --port=$PORT --user=$USERNAME --password=$PASSWORD $DATABASE < db/sql/drug_cms_metadata.sql
+  mysql --host=$HOST --port=$PORT --user=$USERNAME --password=$PASSWORD $DATABASE < db/sql/ntp_regimens.sql
 }
 


### PR DESCRIPTION
add ntp_regimens.sql on the list of files to load when running the "update_art_metadata.sh" script

[Shortcut](https://app.shortcut.com/egpaf-2/story/4719/add-ntp-regimens-sql-on-the-list-of-files-to-load-when-running-the-update-art-metadata-sh-script)