### PR TITLE
add password policy migration

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -4,6 +4,7 @@ module Api
   module V1
     class UsersController < ApplicationController
       DEFAULT_ROLENAME = 'clerk'
+      include PasswordPolicy
 
       skip_before_action :authenticate, only: [:login]
 
@@ -119,7 +120,7 @@ module Api
       end
 
       def user
-        User.find(params[:user_id])
+        User.find(params[:id])
       end
 
       # validate user programs here

--- a/app/controllers/concerns/password_policy.rb
+++ b/app/controllers/concerns/password_policy.rb
@@ -1,0 +1,77 @@
+module PasswordPolicy
+  extend ActiveSupport::Concern
+
+  class UserUpdateError < InvalidParameterError; end
+
+  included do
+    before_action :validate_password, only: [:update]
+  end
+
+  private
+
+  def user_last_used_passwords_props(user:)
+    UserProperty
+      .where(user_id: user.id)
+      .where("property like ?", ["last_used_password_%"])
+  end
+
+  def passwords_match?(saved_password:, password_input:)
+    Digest::SHA1.hexdigest("#{password_input}#{user.salt}") == saved_password \
+      || Digest::SHA512.hexdigest("#{password_input}#{user.salt}") == saved_password
+  end
+
+  def password_valid?(user:, password_input:)
+    if password_input.length < 6
+      raise UserUpdateError, "Password must be at least 6 characters in length"
+    end
+
+    # check if password is same as any of the last used passwords
+    if user_last_used_passwords_props(user:).any?\
+       { |up| passwords_match?(saved_password: up.property_value, password_input:) }
+       
+      raise UserUpdateError, "Password cannot be the same as previously used passwords"
+    end
+
+    true
+  end
+
+  def add_password_to_user_props(user:)
+    pass_count = 1
+    random = Random.rand(1..6)
+    passwords_properties = self.user_last_used_passwords_props(user:).pluck("property")
+
+    if (passwords_properties.length >= 6)
+      # delete random saved password
+      UserProperty
+        .where(user_id: user.id)
+        .where("property = ?", "last_used_password_#{random}")
+        .delete_all
+        
+      passwords_properties.delete("last_used_password_#{random}")
+    end
+
+    while pass_count <= 6
+      if !passwords_properties.include?("last_used_password_#{pass_count}")
+        UserProperty
+          .create(
+            user_id: user.id,
+            property: "last_used_password_#{pass_count}",
+            property_value: Digest::SHA512.hexdigest("#{params[:password]}#{user.salt}"),
+          )
+        break
+      else
+        pass_count += 1
+      end
+    end
+  end
+
+  def validate_password
+    ActiveRecord::Base.transaction do
+      return true unless params[:password]
+
+      user = User.find(params[:id])
+
+      add_password_to_user_props(user:) if password_valid?(user:, password_input: params[:password])
+    end
+  end
+end

--- a/app/services/user_service.rb
+++ b/app/services/user_service.rb
@@ -31,6 +31,10 @@ module UserService
 
     salt = SecureRandom.base64
 
+    if password.length < 6
+      raise UserCreateError, 'Password must be at least 6 characters in length'
+    end
+
     user = User.create(
       username:,
       # WARNING: Consider using bcrypt (not SHA1 or SHA512) for better security

--- a/app/services/user_service.rb
+++ b/app/services/user_service.rb
@@ -10,6 +10,7 @@ module UserService
   LOGGER = Logger.new $stdout
 
   class UserCreateError < StandardError; end
+  class UserUpdateError < InvalidParameterError; end
 
   def self.find_users(role: nil)
     query = User.all
@@ -50,6 +51,12 @@ module UserService
     user
   end
 
+  def self.password_valid?(password)
+    if password.length < 6
+      raise UserUpdateError, 'Password must be at least 6 characters in length'
+    end
+  end
+
   def self.update_user(user, params)
     # Update person name if specified
     if params.include?(:given_name) || params.include?(:family_name)
@@ -60,7 +67,7 @@ module UserService
     end
 
     # Update password if any
-    if params[:password]
+    if params[:password] && password_valid?(params[:password])
       user.password = Digest::SHA1.hexdigest "#{params[:password]}#{user.salt}"
       user.save
     end

--- a/app/services/user_service.rb
+++ b/app/services/user_service.rb
@@ -31,8 +31,6 @@ module UserService
 
     salt = SecureRandom.base64
 
-    password_valid?(password)
-
     user = User.create(
       username:,
       # WARNING: Consider using bcrypt (not SHA1 or SHA512) for better security
@@ -53,12 +51,6 @@ module UserService
     user
   end
 
-  def self.password_valid?(password)
-    if password.length < 6
-      raise UserUpdateError, 'Password must be at least 6 characters in length'
-    end
-  end
-
   def self.update_user(user, params)
     # Update person name if specified
     if params.include?(:given_name) || params.include?(:family_name)
@@ -69,7 +61,7 @@ module UserService
     end
 
     # Update password if any
-    if params[:password] && password_valid?(params[:password])
+    if params[:password]
       user.password = Digest::SHA1.hexdigest "#{params[:password]}#{user.salt}"
       user.save
     end

--- a/app/services/user_service.rb
+++ b/app/services/user_service.rb
@@ -31,9 +31,7 @@ module UserService
 
     salt = SecureRandom.base64
 
-    if password.length < 6
-      raise UserCreateError, 'Password must be at least 6 characters in length'
-    end
+    password_valid?(password)
 
     user = User.create(
       username:,

--- a/db/migrate/20241011080330_password_policies.rb
+++ b/db/migrate/20241011080330_password_policies.rb
@@ -4,10 +4,10 @@ class PasswordPolicies < ActiveRecord::Migration[7.0]
     user_props = UserProperty
 
     # enable password policy
-    props.find_by_property('password_policy_enabled')&.update(property_value: 'true')
+    handle_policy(props:, property: 'password_policy_enabled', property_value: 'true')
 
     # set password reset interval to 30 days
-    props.find_by_property('password_reset_interval')&.update(property_value: '30')
+    handle_policy(props:, property: 'password_reset_interval', property_value: '30')
 
     # set all user props to forcefully reset passwords
     reset_period = Date.today - 31.days
@@ -20,6 +20,15 @@ class PasswordPolicies < ActiveRecord::Migration[7.0]
         next
       end
       uprop.update(property_value: reset_period)
+    end
+  end
+
+  def handle_policy(props:, property:, property_value:)
+    policy = props.find_by_property(property)
+    if policy.blank?
+      props.create!(property:, property_value:)
+    else
+      policy.update!(property_value:)
     end
   end
 end

--- a/db/migrate/20241011080330_password_policies.rb
+++ b/db/migrate/20241011080330_password_policies.rb
@@ -10,6 +10,15 @@ class PasswordPolicies < ActiveRecord::Migration[7.0]
     props.find_by_property('password_reset_interval')&.update(property_value: '30')
 
     # set all user props to forcefully reset passwords
-    user_props.where(property: 'last_password_reset').update_all(property_value: Date.today - 31.days)
+    User.all.each do |user|
+      uprop = user_props.find_or_initialize_by(user_id: user.id, property: 'last_password_reset')
+      if uprop.new_record?
+        uprop.property_value = Date.today - 31.days
+        uprop.save!
+
+        next
+      end
+      uprop.update(property_value: Date.today - 31.days)
+    end
   end
 end

--- a/db/migrate/20241011080330_password_policies.rb
+++ b/db/migrate/20241011080330_password_policies.rb
@@ -10,15 +10,16 @@ class PasswordPolicies < ActiveRecord::Migration[7.0]
     props.find_by_property('password_reset_interval')&.update(property_value: '30')
 
     # set all user props to forcefully reset passwords
+    reset_period = Date.today - 31.days
     User.all.each do |user|
       uprop = user_props.find_or_initialize_by(user_id: user.id, property: 'last_password_reset')
       if uprop.new_record?
-        uprop.property_value = Date.today - 31.days
+        uprop.property_value = reset_period
         uprop.save!
 
         next
       end
-      uprop.update(property_value: Date.today - 31.days)
+      uprop.update(property_value: reset_period)
     end
   end
 end

--- a/db/migrate/20241011080330_password_policies.rb
+++ b/db/migrate/20241011080330_password_policies.rb
@@ -1,0 +1,15 @@
+class PasswordPolicies < ActiveRecord::Migration[7.0]
+  def change
+    props = GlobalProperty
+    user_props = UserProperty
+
+    # enable password policy
+    props.find_by_property('password_policy_enabled')&.update(property_value: 'true')
+
+    # set password reset interval to 30 days
+    props.find_by_property('password_reset_interval')&.update(property_value: '30')
+
+    # set all user props to forcefully reset passwords
+    user_props.where(property: 'last_password_reset').update_all(property_value: Date.today - 31.days)
+  end
+end


### PR DESCRIPTION
## Changes in the codebase

### Enforce password policies using migration

- Update password_reset_interval to 30 days
- Enable Password Policies for all
- Force users to immediately reset password

### Add password validation

- Length Must be >= 6 Characters