### PR TITLE
Outcome Fixes

### DIFF
--- a/app/services/art_service/reports/cohort/outcomes.rb
+++ b/app/services/art_service/reports/cohort/outcomes.rb
@@ -300,9 +300,9 @@ module ArtService
             INSERT INTO temp_patient_outcomes#{start ? '_start' : ''}
             SELECT patient_id,
                    patient_outcome(patient_id, #{function_date}),
-                   NULL,
+                   current_defaulter_date(patient_id, #{function_date}),
                    pepfar_patient_outcome(patient_id, #{function_date}),
-                   NULL,
+                   current_pepfar_defaulter_date(patient_id, #{function_date}),
                    5
             FROM temp_earliest_start_date
             WHERE date_enrolled < DATE(#{start ? start_date : end_date}) + INTERVAL 1 DAY


### PR DESCRIPTION
## Context
* Adding outcomes dates for step 5
* Step 5 uses MySQL functions to find the outcome but not the outcome date
* this fix adds the much needed outcome date

## Ticket
[Shortcut](https://app.shortcut.com/egpaf-2/story/4973/fix-pepfar-and-moh-defaulters-list-picking-defaulters-outside-the-specified-period)