### PR TITLE
Chore/custom_autoincrement_ids

### DIFF
--- a/app/models/concerns/auditable.rb
+++ b/app/models/concerns/auditable.rb
@@ -17,6 +17,7 @@ module Auditable
   included do
     before_save :update_change_trail
     before_create :update_create_trail
+    before_create :auto_increment_composite_key
   end
 
   # Saves current user after every save
@@ -43,6 +44,29 @@ module Auditable
 
     self.date_created = Time.now
   end
+
+  def composite_key?
+    self.class.composite? && (self.class.primary_key.is_a?(Array) && self.class.primary_key.length == 2)
+  end
+
+  def composite_key_has_site_id?
+    self.class.primary_key.include?('site_id')
+  end
+
+  # rubocop:disable Metrics/AbcSize
+  def auto_increment_composite_key
+    return unless composite_key? && composite_key_has_site_id?
+
+    composite_key_column = (self.class.primary_key - ['site_id']).first
+    unless composite_key_column && respond_to?(:site_id) && respond_to?(composite_key_column.to_sym)
+      Rails.logger.warn "Auditable model missing site_id or #{composite_key_column}: #{self}"
+      return
+    end
+
+    last_value = self.class.where(site_id:).maximum(composite_key_column.to_sym) || 0
+    self[composite_key_column] = last_value + 1
+  end
+  # rubocop:enable Metrics/AbcSize
 
   def auditable?
     respond_to?(:changed_by) && respond_to?(:date_changed)


### PR DESCRIPTION
## Context
Due to the transition to centralized emr, introduction of composite key onto transaction table has be introduced to be able to identify source site. The PR has been raised to address the issue of autoincrementing composite key part for the same site id record on creating to ensure uniqueness.

## Description
The task will only have to work on transaction table that have composite keys where by one of the keys has to be site id. For site id in question, get the maximum value of the other composite key  and increment it by one before saving. 

## Changes in the codebase
To achieve this goal, the auditable concern has been update to handle increments of the other composite key part of the site id composite before record creation. The functionality first check if the model has a composite key, then if that composite key lenght 2 (i.e an array of 2). There after if the composite key has a site id as on the the keys.  So for any model that responds to site id and the other composite key, the other composite key is incremented before save. 

## Changes outside the codebase
N/A

## Aditional information
The functionality check for lenght to be equal to 2 because the assumption is that the composite key will only contain site id and 1 other column.

## Ticket
[Shortcut ticket:](https://app.shortcut.com/egpaf-2/story/5119/create-custom-autoincrement-feature-for-ids)