### PR TITLE
FIX: (Maternal status) handling patient_ids args

### DIFF
--- a/app/services/art_service/reports/maternal_status.rb
+++ b/app/services/art_service/reports/maternal_status.rb
@@ -18,14 +18,11 @@ module ArtService
         @occupation = kwargs.delete(:occupation)
         @type = kwargs.delete(:application)
         ids = kwargs.delete(:patient_ids)
-        @patient_ids = case ids.class
-                       when String
-                         ids.split(',').map(&:to_i)
-                       when Array
-                         ids
-                       else
-                         []
-                       end
+        transformed = []
+        transformed = ids.split(',').map(&:to_i) if ids.class == String
+        transformed = ids if ids.class == Array
+
+        @patient_ids = transformed       
       end
 
       def find_report


### PR DESCRIPTION
## Context

When parsing patient_ids in the report, you can either use an array of patient_ids or a comma seperated string of patient_ids

## Description

The API checks for the class of args (String, Array) and maps then to an integer list, else returns an empty (fallback). this method is done during report initialization. this transformation block was buggy because it was always returning an empty array as the transformed list.

## Changes in the codebase

- Seperate the arg type checks to pin point the areas of failure
- Update checks instead of a case, added an if condition


## Screenshots

### Response after fix

![image](https://github.com/user-attachments/assets/4e811837-e9d5-400c-85d7-0e4a54f62248)
