### PR TITLE
Feat: add lab audit trail

### DIFF
--- a/app/services/art_service/report_engine.rb
+++ b/app/services/art_service/report_engine.rb
@@ -57,7 +57,8 @@ module ArtService
       'TX_NEW' => ArtService::Reports::Pepfar::TxNew,
       'MATERNAL_STATUS' => ArtService::Reports::MaternalStatus,
       'NID_CUMULATIVE_REPORT' => ArtService::Reports::Clinic::NidCumulativeReport,
-      'TX_HIV_HTN' => ArtService::Reports::Pepfar::TxHivHtn
+      'TX_HIV_HTN' => ArtService::Reports::Pepfar::TxHivHtn,
+      'LAB_AUDIT_TRAIL' => ArtService::Reports::Clinic::LabAuditTrailReport
     }.freeze
 
     def generate_report(type:, **kwargs)

--- a/app/services/art_service/reports/clinic/lab_audit_trail_report.rb
+++ b/app/services/art_service/reports/clinic/lab_audit_trail_report.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module ArtService
+  module Reports
+    module Clinic
+      # Generates a lab audit trail report for a clinic
+      class LabAuditTrailReport
+        
+        def initialize(start_date:, end_date:, **_kwargs)
+          @start_date = ActiveRecord::Base.connection.quote(start_date)
+          @end_date = ActiveRecord::Base.connection.quote(end_date)
+        end
+
+        def find_report
+          ActiveRecord::Base.connection.select_all <<~SQL
+            SELECT
+                orders.accession_number,
+                IF(result.present, 'Order and Result', 'Order') lab_encounter,
+                DATE(e.date_changed) change_date,
+                COALESCE(e.void_reason, 'N/A') reason_for_the_change,
+                CONCAT(COALESCE(pn.given_name, ''), ' ', COALESCE(pn.family_name, '')) user,
+                IF(e.voided, 'Void', 'Update') AS change_type,
+                orders.order_id
+            FROM encounter e
+            INNER JOIN encounter_type et ON et.encounter_type_id = e.encounter_type
+                AND et.name IN ('LAB ORDERS', 'LAB RESULTS')
+            INNER JOIN obs o ON o.encounter_id = e.encounter_id
+            INNER JOIN users u ON u.user_id = e.changed_by
+            INNER JOIN person_name pn ON pn.person_id = u.person_id
+            INNER JOIN orders ON orders.encounter_id = e.encounter_id
+            LEFT JOIN (
+                SELECT e.encounter_id, o.obs_id, o.order_id, res.concept_id present
+                FROM obs o
+                INNER JOIN encounter e ON e.encounter_id = o.encounter_id
+                INNER JOIN obs res ON res.obs_group_id = o.obs_id
+                WHERE o.concept_id = #{concept('Lab test result').id}
+            ) AS result ON result.order_id = orders.order_id
+            WHERE e.date_created != e.date_changed
+            AND DATE(e.encounter_datetime) >= #{@start_date}
+            AND DATE(e.encounter_datetime) <= #{@end_date}
+            GROUP BY orders.accession_number
+          SQL
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context
add lab audit trail report to track voids and updates in lab activities

## Description
Add an audit trail for lab activities
The audit trail should be in the administration tab in the data management section.

## Aditional information
### Endpoint
`{{base_url}}/programs/1/reports/LAB_AUDIT_TRAIL?start_date=2023-01-01&end_date=2025-12-31&date=2025-01-11&`

### Response

```json
[
    {
        "accession_number": "XKPC237E1",
        "lab_encounter": "Order and Result",
        "change_date": "2023-08-17",
        "reason_for_the_change": "Mistake/ Wrong Entry",
        "user": "EMR user",
        "change_type": "Void",
        "order_id": 13677
    },
    {
        "accession_number": "XKPC237M1",
        "lab_encounter": "Order and Result",
        "change_date": "2023-10-02",
        "reason_for_the_change": "Mistake/ Wrong Entry",
        "user": "Another user",
        "change_type": "Void",
        "order_id": 13685
    }]
```


## Ticket
[Link](https://app.shortcut.com/egpaf-2/story/4414/add-an-audit-trail-for-lab-activities)
