### PR TITLE
fix LA 1 drug inventory id

### DIFF
--- a/app/services/opd_service/reports/la_prescriptions.rb
+++ b/app/services/opd_service/reports/la_prescriptions.rb
@@ -26,8 +26,8 @@ module OpdService
         program_id = Program.find_by_name('OPD Program')&.program_id
         raise 'OPD Program not found in programs table' unless program_id
 
-        la_one_drug_id = begin
-          Drug.find_by_name('Lumefantrine + Arthemether 1 x 6').drug_id
+        la_one_drug_ids = begin
+          Drug.where(name: ['Lumefantrine + Arthemether 1 x 6', 'LA (Lumefantrine + arthemether)']).pluck(:drug_id)
         rescue StandardError
           0
         end
@@ -48,7 +48,7 @@ module OpdService
                 INNER JOIN drug d ON do.drug_inventory_id = d.drug_id
               WHERE e.encounter_type = #{treatment_encounter_type_id}
                 AND e.program_id = #{program_id}
-                AND do.drug_inventory_id = #{la_one_drug_id}
+                AND do.drug_inventory_id IN (#{la_one_drug_ids.join(',')})
                 AND o.order_type_id = #{drug_order_type_id}
                 AND DATE(e.encounter_datetime) >= '#{start_date}'
                 AND DATE(e.encounter_datetime) <= '#{end_date}'


### PR DESCRIPTION
## Issue
LA 1 is being saved as  `LA (Lumefantrine + arthemether)` instead of `Lumefantrine + Arthemether 1 x 6 `

## Resolution

Account for both names in the report