### PR TITLE
Fix: report drilldown

### DIFF
--- a/app/services/art_service/report_engine.rb
+++ b/app/services/art_service/report_engine.rb
@@ -155,10 +155,10 @@ module ArtService
                                                     end_date: end_date.to_date, age_group:, gender:).disaggregated_regimen_distribution
     end
 
-    def tx_mmd_client_level_data(start_date, end_date, patient_ids, org)
+    def tx_mmd_client_level_data(start_date, end_date, patient_ids, org, dsd)
       REPORTS['ARV_REFILL_PERIODS'].new(start_date: start_date.to_date,
                                         end_date: end_date.to_date, min_age: 0, max_age: 0,
-                                        org:, initialize_tables: '').tx_mmd_client_level_data(patient_ids)
+                                        org:, initialize_tables: '', dsd:).tx_mmd_client_level_data(patient_ids)
     end
 
     def tb_prev(start_date, end_date)

--- a/app/services/report_service.rb
+++ b/app/services/report_service.rb
@@ -141,8 +141,8 @@ class ReportService
     engine(@program).disaggregated_regimen_distribution(start_date, end_date, gender, age_group)
   end
 
-  def tx_mmd_client_level_data(start_date, end_date, patient_ids, org)
-    engine(@program).tx_mmd_client_level_data(start_date, end_date, patient_ids, org)
+  def tx_mmd_client_level_data(start_date, end_date, patient_ids, org, dsd)
+    engine(@program).tx_mmd_client_level_data(start_date, end_date, patient_ids, org, dsd)
   end
 
   def tb_prev(start_date, end_date)


### PR DESCRIPTION
added an extra optional param(dsd) in the drilldown which was casusing the crash

```json
status: 500, error: "Internal Server Error",…}
error
: 
"Internal Server Error"
exception
: 
"#<ArgumentError: wrong number of arguments (given 5, expected 4)>"
status
: 
500
```
