### PR TITLE
FIX: (Cohort) - female pregnant cummulative

### DIFF
--- a/app/services/art_service/reports/cohort_builder.rb
+++ b/app/services/art_service/reports/cohort_builder.rb
@@ -1641,7 +1641,7 @@ module ArtService
       def load_temp_pregnant_obs(start_date, end_date)
         ActiveRecord::Base.connection.execute <<~SQL
           INSERT INTO temp_pregnant_obs
-          SELECT o.person_id,o.value_coded, DATE(o.obs_datetime) obs_datetime
+          SELECT o.person_id,o.value_coded, MIN(DATE(o.obs_datetime)) obs_datetime
           FROM obs o
           WHERE o.concept_id IN (6131,1755,7972,7563)
             AND o.value_coded IN (1065,1755)


### PR DESCRIPTION
## Context
When Loading pregnancy status for patients , we query an obs and get the response of "Is patient pregnanct". this will determine if the patient was pregnant during their visit. when generating the cohort report, we load all these obs in a temp table _temp_pregnant_obs_

## Description
Cohort report has a section which aggregates patient who came pregnanct in their first visit, this was achieved by checking if the pregnant obs_date matches the patients first visit date. 

## Bug
if the patient came in pregnant in multiple visits, Query was not always getting the initial pregnant obs. which resulted in some patients categorised as non-pregnant on their initial visit

## Changes in the codebase
Get Initial pregancy obs

## Ticket
[=> => =>](https://app.shortcut.com/egpaf-2/story/5950/fix-the-cohort-report-on-ft-fp-cumulative)