### PR TITLE
chore(migration): add TB numbers migration script

### DIFF
--- a/bin/migrate_tb_numbers.rb
+++ b/bin/migrate_tb_numbers.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+tb_numbers = PatientIdentifier.where(type: PatientIdentifierType.find_by_name('District TB Number'))
+SITE_PREFIX = GlobalProperty.find_by_property('site_prefix').property_value
+
+puts '==================================='
+puts "Migrating TB Numbers to prefix #{SITE_PREFIX}/TB/XXXX/YYYY"
+puts '==================================='
+
+tb_numbers.each do |tb_number|
+  identifier = tb_number.identifier # Example: MPC/TB/78/2016
+
+  # Extract the number and year from the identifier
+  parts = identifier.split('/')
+  if parts.length < 4
+    puts "Invalid identifier format: #{identifier}. Skipping..."
+    next
+  end
+
+  number = parts[2]
+  year = parts[3]
+
+  # Update the identifier with the new prefix
+  new_identifier = "#{SITE_PREFIX}/TB/#{number}/#{year}"
+  if identifier != new_identifier
+    tb_number.update(identifier: new_identifier)
+    puts "Migrated: #{identifier} -> #{new_identifier}"
+  else
+    puts "Already migrated: #{identifier}"
+  end
+end
+
+puts '==================================='
+puts 'Done!'
+puts '==================================='


### PR DESCRIPTION
## Context
The TB Officers are asking that Bwaila Hospital as a mother facility for the district should take its original Alpha Prefixes. We currently have the system indicating "MPC/TB/#*/ Year" and instead it should be  "LL/TB/#*/ Year" .
 LL is standing for Lilongwe as a main District registration center and that is how is recognized by National TB Control Program. 
[Helpdesk reference](https://egpafemr.sdpondemand.manageengine.com/app/itdesk/ui/requests/118246000025412001/details)

## Description

This task involves migrating all TB identifiers in the database to a standardized format using a predefined site prefix. The goal is to ensure that all identifiers conform to the format `#{SITE_PREFIX}/TB/#{number}/#{year}`. Below is a detailed breakdown of how this task will be accomplished:

### Steps to Achieve the Goal
 
1. **Retrieve TB Identifiers**:
   - Query the database to fetch all `Patient_identifier` records where the type matches the `District TB Number` identifier type.

2. **Fetch Site Prefix**:
   - Retrieve the site prefix from the `global_property` table using the property name `site_prefix`. This prefix will be used to construct the new identifier format.

3. **Iterate Through Identifiers**:
   - Loop through each `PatientIdentifier` record retrieved in step 1.

4. **Parse Existing Identifier**:
   - Extract the components of the identifier by splitting it on the `/` character. The expected format is `PREFIX/TB/#{number}/#{year}`.
   - Validate that the identifier contains at least four parts (`PREFIX`, `TB`, `number`, and `year`). If the format is invalid, log the issue and skip the record.

5. **Construct New Identifier**:
   - Use the extracted `number` and `year` components to construct a new identifier in the format `#{SITE_PREFIX}/TB/#{number}/#{year}`.

6. **Update Identifier**:
   - If the existing identifier does not match the newly constructed identifier, update the record with the new identifier.
   - Log the migration, showing the old identifier and the new identifier.

7. **Handle Already Migrated Identifiers**:
   - If the existing identifier already matches the new format, log that the identifier has already been migrated and skip further processing for that record.

8. **Completion**:
   - Once all identifiers have been processed, log a completion message indicating that the migration is done.

### Technical Details

- **Service Integration**:
  - The script integrates with the database using ActiveRecord to query and update `PatientIdentifier` records.
  - The `GlobalProperty` table is queried to fetch the `site_prefix` value.

- **Job Logic**:
  - The script ensures that all identifiers are migrated, regardless of their initial prefix (e.g., `MPC`, `DZ`, etc.).
  - Invalid identifiers are logged but not skipped entirely; they are handled gracefully to avoid breaking the migration process.

- **Implementation**:
  - The script is implemented in Ruby and uses ActiveRecord for database operations.
  - Logging is included to provide visibility into the migration process, including skipped records, already migrated records, and successfully migrated records.

This approach ensures that all TB identifiers are standardized while maintaining a robust and fault-tolerant migration process.

## Ticket
[Helpdesk ticket # 14631](https://egpafemr.sdpondemand.manageengine.com/app/itdesk/ui/requests/118246000025412001/details)

## Use of the script
- #### Note: Before running the script, the site prefix should be changed to the new one on the application side
- rails r bin/migrate_tb_numbers.rb