### PR TITLE
Show dosage strength on label printout

### DIFF
--- a/app/services/art_service/patient_visit.rb
+++ b/app/services/art_service/patient_visit.rb
@@ -251,12 +251,16 @@ module ArtService
                        .gsub(/Isoniazid/i, 'INH')
       end
 
-      match = drug.name.match(/^(.+)\s*\(.*$/)
-      name = match.nil? ? drug.name : match[1]
-
-      name = 'CPT' if name.match?('Cotrimoxazole')
-      # name = 'INH' if name.match?('INH')
-      name
+      # match = drug.name.match(/^(.+)\s*\(.*$/)
+      # name = match.nil? ? drug.name : match[1]
+      name = drug.name
+      if name.match?('Cotrimoxazole')
+        'CPT'
+      elsif name.match?('INH')
+        'INH'
+      else
+        name
+      end
     end
   end
 end


### PR DESCRIPTION
All drugs are now showing dosage strength on ART visit summary

# Issue
Resolves shortcut story:  https://app.shortcut.com/egpaf-2/story/5959/on-the-printout-the-htn-drug-strength-should-be-shown-e-g-5mg/
