### PR TITLE
fix: add deactived users scope

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -9,8 +9,8 @@ module Api
       skip_before_action :authenticate, only: %i[login reset_password]
 
       def index
-        filters = params.permit(:role).to_hash.transform_keys(&:to_sym)
-        render json: service.find_users(**filters)
+        filters = params.permit(%i[role include_deactivated]).to_hash.transform_keys(&:to_sym)
+        render json: service.find_users(filters)
       end
 
       def show

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,8 @@ class User < RetirableRecord
            foreign_key: :person_id,
            dependent: :destroy)
 
+  default_scope { where(deactivated_on: nil) }
+
   def active?
     deactivated_on.nil?
   end

--- a/app/services/user_service.rb
+++ b/app/services/user_service.rb
@@ -28,9 +28,15 @@ module UserService
   class UserCreateError < StandardError; end
   class UserUpdateError < InvalidParameterError; end
 
-  def self.find_users(role: nil)
-    query = User.all
-    query = User.joins(:roles).where(user_role: { role: }) if role
+  def self.find_users(filters = {})
+    include_deactivated = (filters&.keys || []).include?(:include_deactivated)
+
+    query = include_deactivated ? User.unscope(where: :deactivated_on) : User.all
+    
+    role = filters&.dig(:role)
+
+    query = query.joins(:roles).where(user_role: { role: }) if role
+
     query
   end
 


### PR DESCRIPTION
## Issue

When returning list of users, the system was also giving out deactivated users on the provider BDE screeen

## Resolution

By Default The endpoint {baseUrl}/users will filter out deactivated users

- To Include deactivated Users, add a param `include_deactivated` on the request

