### PR TITLE
fix user scope on getting a deactivated creator

### DIFF
--- a/app/models/retirable_record.rb
+++ b/app/models/retirable_record.rb
@@ -17,7 +17,7 @@ class RetirableRecord < ApplicationRecord
   default_scope { where(retired: 0) }
   scope :retired, -> { unscoped.where.not(retired: 0) }
 
-  belongs_to :creator_user, foreign_key: 'creator', class_name: 'User'
+  belongs_to :creator_user, -> { unscope(where: :deactivated_on) }, foreign_key: 'creator', class_name: 'User'
 
   def void(*args, **kwargs)
     # HACK: This should normally be called within the top most scope of

--- a/app/models/voidable_record.rb
+++ b/app/models/voidable_record.rb
@@ -9,5 +9,5 @@ class VoidableRecord < ApplicationRecord
   default_scope { where(voided: 0) }
   scope :voided, -> { unscoped.where.not(voided: 0) }
 
-  belongs_to :creator_user, foreign_key: 'creator', class_name: 'User', optional: true
+  belongs_to :creator_user, -> { unscope(where: :deactivated_on) }, foreign_key: 'creator', class_name: 'User', optional: true
 end


### PR DESCRIPTION
## Context

This [PR](https://github.com/EGPAFMalawiHIS/BHT-EMR-API/pull/162) Adds a scope to filter out deactivated users

## Description
When getting a model record which extends retirable or voided, we get a creator_user for that record. when the user is deactivated the system is failing to update/create the record

## Changes in the codebase
Remove scope when getting the creator user. get the creator user whether deactivated or not