### PR TITLE
TX TB Report updates for PEPF

### DIFF
--- a/app/services/art_service/reports/pepfar/tx_tb.rb
+++ b/app/services/art_service/reports/pepfar/tx_tb.rb
@@ -14,6 +14,7 @@ module ArtService
         def initialize(start_date:, end_date:, **kwargs)
           super(start_date:, end_date:, **kwargs)
           @dsd = kwargs[:dsd]
+          @report_type = kwargs[:report_type]
         end
 
         def find_report
@@ -77,6 +78,7 @@ module ArtService
               current_obs.earliest_start_date as enrollment_date,
               disaggregated_age_group(current_obs.birthdate, DATE('#{end_date.to_date}')) AS age_group,
               cn.name AS tb_status,
+              tpo.pepfar_cum_outcome  AS outcome,
               GROUP_CONCAT(DISTINCT vcn.name) AS screening_methods
             FROM obs o
             INNER JOIN (
@@ -90,6 +92,7 @@ module ArtService
               GROUP BY o.person_id
             ) current_obs ON current_obs.person_id = o.person_id AND current_obs.obs_datetime = o.obs_datetime
             INNER JOIN concept_name cn ON cn.concept_id = o.value_coded AND cn.voided = 0
+            INNER JOIN temp_patient_outcomes tpo ON tpo.patient_id = o.person_id
             LEFT JOIN obs screen_method ON screen_method.concept_id = #{ConceptName.find_by_name('TB screening method used').concept_id} AND screen_method.voided = 0 AND screen_method.person_id = o.person_id AND DATE(screen_method.obs_datetime) = DATE(current_obs.obs_datetime)
             LEFT JOIN concept_name vcn ON vcn.concept_id = screen_method.value_coded AND vcn.voided = 0 AND vcn.name IN ('Chest x-ray', 'MWRD')
             WHERE o.concept_id = #{ConceptName.find_by_name('TB status').concept_id}

--- a/app/services/art_service/reports/pepfar/tx_tb.rb
+++ b/app/services/art_service/reports/pepfar/tx_tb.rb
@@ -78,7 +78,6 @@ module ArtService
               current_obs.earliest_start_date as enrollment_date,
               disaggregated_age_group(current_obs.birthdate, DATE('#{end_date.to_date}')) AS age_group,
               cn.name AS tb_status,
-              tpo.pepfar_cum_outcome  AS outcome,
               GROUP_CONCAT(DISTINCT vcn.name) AS screening_methods
             FROM obs o
             INNER JOIN (
@@ -92,13 +91,17 @@ module ArtService
               GROUP BY o.person_id
             ) current_obs ON current_obs.person_id = o.person_id AND current_obs.obs_datetime = o.obs_datetime
             INNER JOIN concept_name cn ON cn.concept_id = o.value_coded AND cn.voided = 0
-            INNER JOIN temp_patient_outcomes tpo ON tpo.patient_id = o.person_id
+            INNER JOIN obs patient_present ON patient_present.person_id = o.person_id
+              AND patient_present.concept_id = #{ConceptName.find_by_name('Patient present').concept_id}
+              AND patient_present.value_coded = #{ConceptName.find_by_name('Yes').concept_id}
+              AND patient_present.voided = 0
             LEFT JOIN obs screen_method ON screen_method.concept_id = #{ConceptName.find_by_name('TB screening method used').concept_id} AND screen_method.voided = 0 AND screen_method.person_id = o.person_id AND DATE(screen_method.obs_datetime) = DATE(current_obs.obs_datetime)
             LEFT JOIN concept_name vcn ON vcn.concept_id = screen_method.value_coded AND vcn.voided = 0 AND vcn.name IN ('Chest x-ray', 'MWRD')
             WHERE o.concept_id = #{ConceptName.find_by_name('TB status').concept_id}
             AND o.voided = 0 #{@report_type == 'moh' ? '' : "AND o.person_id IN (#{@tx_curr.join(',')})"}
             AND o.value_coded IN (SELECT concept_id FROM concept_name WHERE name IN ('TB Suspected', 'TB NOT suspected') AND voided = 0)
             AND o.obs_datetime BETWEEN '#{start_date}' AND '#{end_date}'
+            AND patient_present.obs_datetime BETWEEN '#{start_date}' AND '#{end_date}'
             GROUP BY o.person_id
           SQL
         end

--- a/app/services/art_service/reports/pepfar/tx_tb.rb
+++ b/app/services/art_service/reports/pepfar/tx_tb.rb
@@ -230,9 +230,17 @@ module ArtService
         end
 
         def process_method(metrics, methods, patient_id)
-          metrics[:symptom_screen_alone] << patient_id if methods.blank?
-          metrics[:cxr_screen] << patient_id if methods&.include?('chest x-ray') && !methods&.include?('mwrd')
-          metrics[:mwrd_screen] << patient_id if methods&.include?('mwrd')
+          # Hierarchical classification - patient counted in only one indicator
+          if methods&.include?('mwrd')
+            # If mWRD is used, count under mWRD regardless of other methods
+            metrics[:mwrd_screen] << patient_id
+          elsif methods&.include?('chest x-ray')
+            # If CXR is used (but not mWRD), count under CXR
+            metrics[:cxr_screen] << patient_id
+          else
+            # If neither mWRD nor CXR is used, count under symptom screening
+            metrics[:symptom_screen_alone] << patient_id
+          end
         end
 
         # rubocop:enable Metrics/AbcSize


### PR DESCRIPTION
# Features
1. TB indicators no longer include patients who've had exclusive guardian visits during 6 month period(or reporting time range given)
2. TB indicators is now strictly retrieving patient who're in TxCurr
3. Patient appear in one screening criteria at a time based on hierachy of mwrd >> chest x-ray >> screen alone