### PR TITLE
feat: Add migration to enforce a 90-day password reset interval

### DIFF
--- a/db/migrate/20250626000001_update_password_reset_interval.rb
+++ b/db/migrate/20250626000001_update_password_reset_interval.rb
@@ -1,0 +1,34 @@
+class UpdatePasswordResetInterval < ActiveRecord::Migration[7.0]
+  def change
+    # Enforce password reset interval to 90 days, overriding any existing value
+    policy = GlobalProperty.find_by_property('password_reset_interval')
+    
+    if policy.present?
+      policy.update!(property_value: '90')
+    else
+      # Create the policy if it doesn't exist
+      GlobalProperty.create!(property: 'password_reset_interval', property_value: '90')
+
+      # Force all users to reset passwords with the new 91-day period
+      # This ensures compliance with the new 90-day policy
+      reset_period = Date.today - 91.days
+      User.all.each do |user|
+        uprop = UserProperty.find_or_initialize_by(user_id: user.id, property: 'last_password_reset')
+        if uprop.new_record?
+          uprop.property_value = reset_period
+          uprop.save!
+          next
+        end
+        uprop.update(property_value: reset_period)
+      end
+    end
+  end
+
+  def down
+    # Rollback to 30 days if migration is reversed
+    policy = GlobalProperty.find_by_property('password_reset_interval')
+    if policy.present?
+      policy.update!(property_value: '30')
+    end
+  end
+end


### PR DESCRIPTION
This pull request introduces a migration to enforce a new password reset interval policy and ensures compliance across all users. The migration sets the interval to 90 days, updates or creates the global property accordingly, and forces all users to reset their passwords if their last reset exceeds the new interval.

The PR resolves shortcut story number [6773](https://app.shortcut.com/egpaf-2/story/6773/change-the-password-expiry-period-from-30-days-to-90-days-in-the-emr)

Key changes in password reset interval enforcement:

* [`db/migrate/20250626000001_update_password_reset_interval.rb`](diffhunk://#diff-08a10c1256015f64788f87e37d9a29e3f5ebd7e08a4b611c65d1cb27cc3aac75R1-R34): Added a migration to enforce a 90-day password reset interval. The migration updates or creates the `password_reset_interval` global property and adjusts user properties to ensure compliance with the new policy. 