### PR TITLE
Fix wrong concept ids for Reasons of test

### DIFF
--- a/db/migrate/20251202123751_remap_afew_art_test_reasons.rb
+++ b/db/migrate/20251202123751_remap_afew_art_test_reasons.rb
@@ -1,0 +1,17 @@
+class RemapAfewArtTestReasons < ActiveRecord::Migration[7.0]
+  def change
+    id_remap = {
+      1345 => 10230, # Confirmed to Confirmatory
+      6368 => 10254, # Status to Stat
+      9144 => 10228 # Missing to Repeat / Missing
+    }
+
+    concept_id = ConceptName.find_by_name('Reason for test').concept_id
+  
+    id_remap.each do |wrong_id, correct_id|
+      Observation.where(
+        concept_id: concept_id, value_coded: wrong_id
+      ).update_all(value_coded: correct_id)
+    end
+  end
+end


### PR DESCRIPTION
*This change addresses the issue of incorrect concept IDs being used in the Observation records, which can lead to data integrity problems and misinterpretation of test reasons.*



## Description

*The migration remaps specific wrong concept IDs to their correct counterparts in the Observation table. It identifies the concept ID for 'Reason for test' and updates all relevant records accordingly.*



## Changes in the codebase

*Introduced a migration that defines a mapping of incorrect concept IDs to correct ones. The migration iterates through the mapping and updates the Observation records in bulk, ensuring data consistency.*



## Changes outside the codebase

*No changes to external services or infrastructure are included in this migration.*



## Additional information

*This migration is crucial for maintaining accurate data representation in the system and preventing future errors related to test reasons.*



## Ticket

*No specific ticket is referenced for this change.*



## Screenshots

*No visual changes are included in this migration.*

