### PR TITLE
Updated Lab Sticker to show ARV number and other enhancements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem 'rswag-ui'
 
 gem 'emr_ohsp_interface', '~> 2.2.5'
 
-gem 'his_emr_api_lab', '~> 2.0.9'
+gem 'his_emr_api_lab', path: '../his_emr_api_lab'
 
 # gem 'his_emr_api_radiology', '~> 1.0.9'
 


### PR DESCRIPTION
## Context
This change allows for local development by updating the path of the `his_emr_api_lab` gem to point to a local directory, facilitating easier testing and modifications.

# Shortcut
https://app.shortcut.com/egpaf-2/story/7096/17743-request-for-the-viral-load-sticker-to-display-art-number

# Lab germ PR
https://github.com/EGPAFMalawiHIS/his_emr_api_lab/pull/80

# How to test this update
1. Clone or place the `his_emr_api_lab` gem outside the BHT-EMR-API folder
2. In the `his_emr_api_lab` folder, use the terminal and switch to the following branch using git:  `chore/vl_label_update`
3. In the BHT-EMR-API folder, edit the gem file and make sure the `his_emr_api_lab` gem looks like this: 
    `gem 'his_emr_api_lab', path: '../his_emr_api_lab'

# Screenshots
![WhatsApp Image 2025-12-09 at 10 51 03 AM](https://github.com/user-attachments/assets/8eee7be6-7065-46a4-9634-0644d1c8f323)
![WhatsApp Image 2025-12-09 at 10 51 04 AM (1)](https://github.com/user-attachments/assets/cfdde269-6140-483e-94a6-c40801270882)
