### PR TITLE
Revise OPD visit summary label to include relevant lab order data

### DIFF
--- a/app/services/opd_service/visit_label.rb
+++ b/app/services/opd_service/visit_label.rb
@@ -132,8 +132,12 @@ class OpdService::VisitLabel
         lab_orders = []
         encounter.observations.each do |observation|
           concept_name = observation.concept.fullname
-          next if concept_name.match(/Workstation location/i)
-          lab_orders << observation.answer_string.to_s
+          next if concept_name.match(/Workstation location|Comment to fulfiller|Lab test result/i)
+          value = observation.answer_string.to_s
+          if(value.match(/=|>|</i)) 
+            lab_orders << concept_name
+          end
+          lab_orders << value
         end
         label.draw_multi_text("Lab orders: #{lab_orders.join(",")}", concepts_font)
         json_data[:lab_orders] << lab_orders.join(", ")


### PR DESCRIPTION
- This PR resolves shortcut issue number [7149](https://app.shortcut.com/egpaf-2/story/7149/opd-print-has-a-spelling-error-on-lab-results-instead-of-returned-the-printout-is-showing-retired-and-if-multiple-drugs)

