### PR TITLE
Fix order status retrieval and measure concept query

### DIFF
--- a/app/services/art_service/reports/lims_results.rb
+++ b/app/services/art_service/reports/lims_results.rb
@@ -24,7 +24,7 @@ module ArtService
         ActiveRecord::Base.connection.select_all <<~SQL
           SELECT o.start_date AS date_ordered, pn.given_name, pn.family_name, pi.identifier AS arv_number, e.patient_id,
           las.date_received, o.accession_number, CONCAT(COALESCE(res.value_modifier, '='), COALESCE(res.value_text, res.value_numeric)) AS result,
-          cn.name AS test_name, las.acknowledgement_type AS result_delivery_mode, statuses.value_text AS order_status, reason_test.name AS test_reason
+          cn.name AS test_name, las.acknowledgement_type AS result_delivery_mode, latest_test_status.value_text AS order_status, reason_test.name AS test_reason
           FROM orders o
           LEFT JOIN lims_acknowledgement_statuses las ON las.order_id = o.order_id
           INNER JOIN encounter e ON e.encounter_id = o.encounter_id AND e.voided = 0 AND (e.program_id = 1 OR e.program_id = 23) -- HIV PROGRAM AND Laboratory program
@@ -36,10 +36,16 @@ module ArtService
           LEFT JOIN patient_identifier pi ON pi.patient_id = e.patient_id AND pi.voided = 0 AND pi.identifier_type = #{identifier_type}
           LEFT JOIN obs ON obs.person_id = e.patient_id AND obs.voided = 0 AND obs.order_id = o.order_id
             AND obs.concept_id = 7363 -- 'Lab test result'
-          LEFT JOIN obs statuses ON statuses.order_id = o.order_id AND statuses.voided = 0 AND statuses.concept_id = 10682 -- 'lab order status'
           LEFT JOIN obs res ON res.obs_group_id = obs.obs_id AND res.voided = 0 AND res.order_id = o.order_id
           LEFT JOIN obs reason ON reason.order_id = o.order_id AND reason.voided = 0  AND reason.concept_id = 2429 -- 'Reason for test'
           LEFT JOIN concept_name reason_test ON reason_test.concept_id = reason.value_coded AND reason_test.voided = 0
+          LEFT JOIN (
+            SELECT ts.obs_group_id, ts.value_text, ts.obs_datetime,
+                   ROW_NUMBER() OVER (PARTITION BY ts.obs_group_id ORDER BY ts.obs_datetime DESC) AS rn
+            FROM obs AS ts
+            INNER JOIN concept_name AS cn_ts ON cn_ts.concept_id = ts.concept_id AND cn_ts.name = 'Lab Test Status'
+            WHERE ts.voided = 0
+          ) AS latest_test_status ON latest_test_status.obs_group_id = test.obs_id AND latest_test_status.rn = 1
           LEFT JOIN (#{current_occupation_query}) AS a ON a.person_id = e.patient_id
           WHERE DATE(o.start_date) BETWEEN '#{start_date}' AND '#{end_date}' AND o.voided = 0 #{%w[Military Civilian].include?(@occupation) ? 'AND' : ''} #{occupation_filter(occupation: @occupation, field_name: 'value', table_name: 'a', include_clause: false)}
           AND cn.name ="HIV viral load" GROUP BY o.order_id

--- a/app/services/art_service/reports/lims_results.rb
+++ b/app/services/art_service/reports/lims_results.rb
@@ -24,7 +24,7 @@ module ArtService
         ActiveRecord::Base.connection.select_all <<~SQL
           SELECT o.start_date AS date_ordered, pn.given_name, pn.family_name, pi.identifier AS arv_number, e.patient_id,
           las.date_received, o.accession_number, CONCAT(COALESCE(res.value_modifier, '='), COALESCE(res.value_text, res.value_numeric)) AS result,
-          cn.name AS test_name, las.acknowledgement_type AS result_delivery_mode, latest_test_status.value_text AS order_status, reason_test.name AS test_reason
+          cn.name AS test_name, las.acknowledgement_type AS result_delivery_mode, COALESCE(latest_test_status.value_text, statuses.value_text) AS order_status, reason_test.name AS test_reason
           FROM orders o
           LEFT JOIN lims_acknowledgement_statuses las ON las.order_id = o.order_id
           INNER JOIN encounter e ON e.encounter_id = o.encounter_id AND e.voided = 0 AND (e.program_id = 1 OR e.program_id = 23) -- HIV PROGRAM AND Laboratory program
@@ -36,6 +36,7 @@ module ArtService
           LEFT JOIN patient_identifier pi ON pi.patient_id = e.patient_id AND pi.voided = 0 AND pi.identifier_type = #{identifier_type}
           LEFT JOIN obs ON obs.person_id = e.patient_id AND obs.voided = 0 AND obs.order_id = o.order_id
             AND obs.concept_id = 7363 -- 'Lab test result'
+          LEFT JOIN obs statuses ON statuses.order_id = o.order_id AND statuses.voided = 0 AND statuses.concept_id = 10682 -- 'lab order status'
           LEFT JOIN obs res ON res.obs_group_id = obs.obs_id AND res.voided = 0 AND res.order_id = o.order_id
           LEFT JOIN obs reason ON reason.order_id = o.order_id AND reason.voided = 0  AND reason.concept_id = 2429 -- 'Reason for test'
           LEFT JOIN concept_name reason_test ON reason_test.concept_id = reason.value_coded AND reason_test.voided = 0

--- a/app/services/laboratory_service/reports/clinic/processed_results.rb
+++ b/app/services/laboratory_service/reports/clinic/processed_results.rb
@@ -95,6 +95,7 @@ module LaboratoryService
               INNER JOIN concept USING (concept_id)
               WHERE concept.retired = 0
                 AND name NOT LIKE 'Lab test result'
+                AND name NOT LIKE 'Lab Test Status'
               GROUP BY concept_id
             ) AS measure_concept
               ON measure_concept.concept_id = measure.concept_id


### PR DESCRIPTION
## Context
Improving the accuracy of order statuses in the LIMS results report enhances the reliability of test results for users. This change addresses inconsistencies in how order statuses are retrieved and displayed.

## Description
The implementation updates the order status retrieval logic to utilize the latest test status when available. Additionally, it modifies the measure concept query to exclude 'Lab Test Status', ensuring that only relevant data is processed. The PR works with this lab gem pr: [his_emr_lab_api](https://github.com/EGPAFMalawiHIS/his_emr_api_lab/pull/106)

NOTE: NEW CONCEPT TO BE ADDED: ```Lab Test Status```

## Changes in the codebase
The code now includes a subquery to fetch the latest test status for each order, which is used to determine the order status. The measure concept query has been adjusted to filter out 'Lab Test Status', preventing it from affecting the results.

## Changes outside the codebase
No changes to external services or infrastructure are included in this update.

## Additional information
These changes improve the accuracy of the reports generated by the system, which is crucial for clinical decision-making.

## Ticket
No ticket is associated with this pull request.

## Screenshots
No visual changes are included in this update.

