### PR TITLE
Streaming API Commands for Superusers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Table of Contents
     - [Setting up Production mode](#setting-up-production-mode)
     - [Setting up Streaming](#setting-up-streaming)
       - [Pre-requisites](#pre-requisites)
+      - [Streaming Commands](#streaming-commands)
       - [Database](#database)
         - [Using an existing database](#using-an-existing-database)
         - [Using an empty database](#using-an-empty-database)
@@ -123,6 +124,42 @@ bash bin/setup_streaming.sh
 ```
 
 Done !! You can now test the streaming by going to `http://localhost:3000/streaming/`
+
+#### Streaming Commands
+
+The following rake tasks are available for managing streaming:
+
+**Stream incomplete visits for a date range:**
+
+```bash
+rails streaming:incomplete start_date=YYYY-MM-DD end_date=YYYY-MM-DD
+```
+
+This fetches patients with incomplete visits in the given date range using the Data Cleaning Tool and enqueues a streaming job for each patient/date combination.
+
+**Retry all failed streaming jobs:**
+
+```bash
+rails streaming:failed
+```
+
+This retries all failed jobs in SolidQueue using the built-in retry mechanism.
+
+**View current streaming stats:**
+
+```bash
+rails streaming:stats
+```
+
+Displays the current SolidQueue job counts (done, failed, pending, scheduled).
+
+**Check CDR configuration and connectivity:**
+
+```bash
+rails streaming:ping
+```
+
+Validates the CDR configuration in `application.yml` and pings the CDR URL to verify it is reachable.
 
 #### Database
 

--- a/lib/tasks/streaming.rake
+++ b/lib/tasks/streaming.rake
@@ -3,6 +3,23 @@
 require 'rake'
 
 namespace :streaming do
+  def print_streaming_stats(extra = {})
+    jobs_done = SolidQueue::ClaimedExecution.count
+    jobs_failed = SolidQueue::FailedExecution.count
+    jobs_pending = SolidQueue::ReadyExecution.count
+    jobs_scheduled = SolidQueue::ScheduledExecution.count
+
+    puts ""
+    puts "=== Streaming Stats ==="
+    extra.each { |label, value| puts "  #{label}:".ljust(26) + value.to_s }
+    puts "  Jobs done:".ljust(26) + jobs_done.to_s
+    puts "  Jobs failed:".ljust(26) + jobs_failed.to_s
+    puts "  Jobs pending:".ljust(26) + jobs_pending.to_s
+    puts "  Jobs scheduled:".ljust(26) + jobs_scheduled.to_s
+    puts "========================"
+    puts ""
+  end
+
   desc "Setup streaming"
   task setup: :environment do
 
@@ -67,5 +84,173 @@ namespace :streaming do
   rescue => e
     puts "\e[31mStreaming setup failed\e[0m"
     puts e.message
+  end
+
+  desc "Stream incomplete visits for a date range. Usage: rails streaming:incomplete start_date=YYYY-MM-DD end_date=YYYY-MM-DD"
+  task incomplete: :environment do
+    start_date = ENV['start_date']
+    end_date = ENV['end_date']
+
+    if start_date.blank? || end_date.blank?
+      puts "\e[31mError: start_date and end_date are required.\e[0m"
+      puts "Usage: rails streaming:incomplete start_date=YYYY-MM-DD end_date=YYYY-MM-DD"
+      exit 1
+    end
+
+    begin
+      start_date = Date.parse(start_date)
+      end_date = Date.parse(end_date)
+    rescue Date::Error => e
+      puts "\e[31mError: Invalid date format - #{e.message}\e[0m"
+      puts "Dates must be in YYYY-MM-DD format."
+      exit 1
+    end
+
+    # Set a current user — required by WorkflowEngine for loading user activities
+    User.current = User.first
+    unless User.current
+      puts "\e[31mError: No users found in the database.\e[0m"
+      exit 1
+    end
+
+    puts "Fetching incomplete visits from #{start_date} to #{end_date}..."
+
+    results = ArtService::DataCleaningTool.new(
+      start_date: start_date,
+      end_date: end_date,
+      tool_name: 'INCOMPLETE VISITS'
+    ).results
+
+    if results.is_a?(String)
+      puts "\e[31mData cleaning tool error: #{results}\e[0m"
+      exit 1
+    end
+
+    if results.blank?
+      puts "\e[33mNo incomplete visits found for the given date range.\e[0m"
+      exit 0
+    end
+
+    puts "Found #{results.keys.length} patients with incomplete visits."
+
+    jobs_enqueued = 0
+
+    begin
+      ActiveRecord::Base.establish_connection(:queue)
+
+      results.each do |patient_id, details|
+        details[:dates].each do |date|
+          StreamingJob.perform_later(
+            patient_id: patient_id,
+            program_id: 1,
+            date: date.to_date.strftime('%Y-%m-%d')
+          )
+          jobs_enqueued += 1
+        end
+      end
+
+      print_streaming_stats('Jobs enqueued (this run)' => jobs_enqueued)
+      puts "\e[32mStreaming incomplete visits completed successfully.\e[0m"
+    rescue => e
+      puts "\e[31mStreaming incomplete visits failed: #{e.message}\e[0m"
+    ensure
+      ActiveRecord::Base.establish_connection(:primary)
+    end
+  end
+
+  desc "Re-stream all failed jobs from SolidQueue. Usage: rails streaming:failed"
+  task failed: :environment do
+    begin
+      ActiveRecord::Base.establish_connection(:queue)
+
+      failed_executions = SolidQueue::FailedExecution.includes(:job).all
+
+      if failed_executions.empty?
+        puts "\e[33mNo failed jobs found.\e[0m"
+        next
+      end
+
+      puts "Found #{failed_executions.count} failed jobs. Retrying..."
+
+      failed_jobs = failed_executions.map(&:job)
+      SolidQueue::FailedExecution.retry_all(failed_jobs)
+
+      print_streaming_stats('Jobs retried' => failed_jobs.size)
+      puts "\e[32mFailed jobs retry completed successfully.\e[0m"
+    rescue => e
+      puts "\e[31mFailed jobs retry failed: #{e.message}\e[0m"
+    ensure
+      ActiveRecord::Base.establish_connection(:primary)
+    end
+  end
+
+  desc "Show current SolidQueue streaming stats. Usage: rails streaming:stats"
+  task stats: :environment do
+    begin
+      ActiveRecord::Base.establish_connection(:queue)
+      print_streaming_stats
+    rescue => e
+      puts "\e[31mFailed to fetch streaming stats: #{e.message}\e[0m"
+    ensure
+      ActiveRecord::Base.establish_connection(:primary)
+    end
+  end
+
+  desc "Check CDR configuration and ping the CDR URL. Usage: rails streaming:ping"
+  task ping: :environment do
+    cdr_config = YAML.load_file(Rails.root.join('config', 'application.yml'))['cdr']
+
+    unless cdr_config
+      puts "\e[31mError: CDR configuration not found in application.yml.\e[0m"
+      puts "Add a 'cdr' section with url, username, and password."
+      exit 1
+    end
+
+    url = cdr_config['url']
+    username = cdr_config['username']
+    password = cdr_config['password']
+
+    puts "=== CDR Configuration ==="
+    puts "  URL:      #{url}"
+    puts "  Username: #{username}"
+    puts "  Password: #{'*' * password.to_s.length}"
+    puts "========================="
+    puts ""
+
+    %w[url username password].each do |key|
+      next if cdr_config[key].present?
+
+      puts "\e[31mError: '#{key}' is missing from CDR configuration.\e[0m"
+      exit 1
+    end
+
+    puts "Pinging #{url}..."
+
+    require 'net/http'
+    uri = URI.parse(url)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = uri.scheme == 'https'
+    http.open_timeout = 10
+    http.read_timeout = 10
+
+    request = Net::HTTP::Post.new(uri.request_uri, { 'Content-Type' => 'application/json' })
+    request.body = '{}'
+    response = http.request(request)
+
+    if response.code.to_i < 400
+      puts "\e[32mResponse: #{response.code} #{response.message} — CDR is reachable.\e[0m"
+    elsif response.code.to_i >= 500
+      puts "\e[32mCDR is reachable.\e[0m"
+    else
+      puts "\e[33mResponse: #{response.code} #{response.message}\e[0m"
+    end
+  rescue Errno::ECONNREFUSED
+    puts "\e[31mConnection refused — CDR server is not running at #{url}\e[0m"
+  rescue Net::OpenTimeout, Net::ReadTimeout
+    puts "\e[31mTimeout — CDR server at #{url} did not respond within 10 seconds.\e[0m"
+  rescue SocketError => e
+    puts "\e[31mDNS/Network error — #{e.message}\e[0m"
+  rescue => e
+    puts "\e[31mFailed to ping CDR: #{e.message}\e[0m"
   end
 end


### PR DESCRIPTION
Added the following streaming related commands you can run on you EMR terminal
1. `rails streaming:ping` - Check if Cdr is reachable
2. `rails streaming:failed` - Stream all failed jobs
3. `rails streaming:incomplete` - Stream all incomplete visits
4. `rails streaming:stats` - View streaming stats from the terminal

These commands are for Linux admins