### PR TITLE
Get latest TB Observations date for drilldown

### DIFF
--- a/app/controllers/api/v1/reports_controller.rb
+++ b/app/controllers/api/v1/reports_controller.rb
@@ -143,7 +143,10 @@ module Api
       end
 
       def cohort_report_drill_down
-        render json: service.cohort_report_drill_down(params[:id])
+        start_date = params[:start_date].presence&.to_date || Date.today
+        end_date = params[:end_date].presence&.to_date || Date.today
+
+        render json: service.cohort_report_drill_down(params[:id], start_date, end_date)
       end
 
       def regimen_switch

--- a/app/services/art_service/report_engine.rb
+++ b/app/services/art_service/report_engine.rb
@@ -101,10 +101,13 @@ module ArtService
                          end_date: end_date.to_date).ipt_coverage
     end
 
-    def cohort_report_drill_down(id)
+    def cohort_report_drill_down(id, start_date, end_date)
+      start_date = start_date.presence || Date.today
+      end_date = end_date.presence || Date.today
+
       REPORTS['COHORT'].new(type: 'drill_down',
-                            name: 'drill_down', start_date: Date.today,
-                            end_date: Date.today).cohort_report_drill_down(id)
+                            name: 'drill_down', start_date: start_date.to_date,
+                            end_date: end_date.to_date).cohort_report_drill_down(id)
     end
 
     def regimen_switch(start_date, end_date, pepfar, **kwargs)

--- a/app/services/art_service/reports/art_cohort.rb
+++ b/app/services/art_service/reports/art_cohort.rb
@@ -95,13 +95,21 @@ module ArtService
           LEFT JOIN patient_identifier i ON i.patient_id = p.person_id
           AND i.voided = 0 AND i.identifier_type = 4
           LEFT JOIN person_name n ON n.person_id = p.person_id AND n.voided = 0
-          LEFT JOIN obs tb_start ON tb_start.person_id = p.person_id
-            AND tb_start.concept_id = (
-              SELECT concept_id 
-              FROM concept_name 
-              WHERE name = 'TB status' 
-              LIMIT 1
-            )
+          LEFT JOIN obs tb_start ON tb_start.obs_id = (
+            SELECT o.obs_id
+            FROM obs o
+            WHERE o.person_id = p.person_id
+              AND o.voided = 0
+              AND o.obs_datetime < DATE('#{@end_date}') + INTERVAL 1 DAY
+              AND o.concept_id = (
+                SELECT concept_id
+                FROM concept_name
+                WHERE name = 'TB status'
+                LIMIT 1
+              )
+            ORDER BY o.obs_datetime DESC, o.date_created DESC, o.obs_id DESC
+            LIMIT 1
+          )
           WHERE c.reporting_report_design_resource_id = #{id}
           GROUP BY p.person_id ORDER BY p.person_id, p.date_created;
         SQL

--- a/app/services/report_service.rb
+++ b/app/services/report_service.rb
@@ -96,8 +96,8 @@ class ReportService
     engine(@program).ipt_coverage(start_date, end_date)
   end
 
-  def cohort_report_drill_down(id)
-    engine(@program).cohort_report_drill_down(id)
+  def cohort_report_drill_down(id, start_date, end_date)
+    engine(@program).cohort_report_drill_down(id, start_date, end_date)
   end
 
   def regimen_switch(start_date, end_date, pepfar, **kwargs)


### PR DESCRIPTION
1. Fix query to get latest tb status obs
2. Filtering TB obs date by report  end_date. Please update the frontend tagged with this PR to send correct dates